### PR TITLE
Add Micro::Struct[] as an alias of Micro::Struct.with

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,7 @@ require:
   - rubocop-minitest
 
 AllCops:
+  NewCops: enable
   TargetRubyVersion: 2.5
 
 # == Gemspec ==
@@ -50,6 +51,9 @@ Style/Lambda:
 Style/LambdaCall:
   Enabled: false
 
+Style/ModuleFunction:
+  EnforcedStyle: extend_self
+
 Style/RaiseArgs:
   EnforcedStyle: compact
 
@@ -76,7 +80,6 @@ Layout/SpaceInsideArrayLiteralBrackets:
 
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
-  EnforcedStyleForEmptyBrackets: no_space
 
 # == Lint ==
 
@@ -116,3 +119,11 @@ Metrics/MethodLength:
 Metrics/ClassLength:
   Exclude:
     - test/**/*.rb
+
+# == Minitest ==
+
+Minitest/AssertWithExpectedArgument:
+  Enabled: false
+
+Minitest/MultipleAssertions:
+  Max: 21

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -5,3 +5,6 @@
 # one by one as the offenses are removed from the code base.
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
+
+Gemspec/RequireMFA:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Diff](https://github.com/serradura/u-struct/compare/v1.0.0...main)
 
+### Added
+
+- Add `Micro::Struct[]` as an alias of `Micro::Struct.with`.
+  ```ruby
+  Micro::Struct[:readonly] # is the same as Micro::Struct.with(:readonly)
+  ```
+
+**Development stuff**
+
+- Set up Rubocop.
 - Add `.rbi` files, and set up sorbet to be used in development.
+
+<p align="right">(<a href="#changelog-">⬆️ &nbsp;back to top</a>)</p>
 
 <p align="right">(<a href="#changelog-">⬆️ &nbsp;back to top</a>)</p>
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
     - [`required:` option](#required-option)
     - [Defining custom methods/behavior](#defining-custom-methodsbehavior)
   - [`Micro::Struct.with`](#microstructwith)
+  - [`Micro::Struct[]`](#microstruct)
     - [`:to_ary`](#to_ary)
     - [`:to_hash`](#to_hash)
     - [`:to_proc`](#to_proc)
@@ -324,6 +325,15 @@ new_person == person
 
 new_person.class == person.class
 # true
+```
+
+<p align="right">(<a href="#table-of-contents-">⬆️ &nbsp;back to top</a>)</p>
+
+### `Micro::Struct[]`
+
+The `[]` brackets method is as an alias of `Micro::Struct.with`. e.g.
+```ruby
+Micro::Struct[:readonly, :to_hash] # is the same as Micro::Struct.with(:readonly, :to_hash)
 ```
 
 <p align="right">(<a href="#table-of-contents-">⬆️ &nbsp;back to top</a>)</p>

--- a/lib/micro/struct.rb
+++ b/lib/micro/struct.rb
@@ -59,15 +59,19 @@ module Micro
   #
   #   Micro::Struct.with(*features).new(...) {}
   module Struct
-    def self.new(*members, required: nil, optional: nil, &block)
-      with.__create__(members, required, optional, block)
-    end
+    extend self
 
-    def self.with(*feature_names)
+    def with(*feature_names)
       Factory.new(feature_names)
     end
 
-    def self.instance(**members, &block)
+    alias_method :[], :with
+
+    def new(*members, required: nil, optional: nil, &block)
+      with.__create__(members, required, optional, block)
+    end
+
+    def instance(**members, &block)
       with.instance(**members, &block)
     end
   end

--- a/rbi/micro/struct.rbi
+++ b/rbi/micro/struct.rbi
@@ -5,6 +5,18 @@ module Micro::Struct
   STRUCT_BLOCK  = T.type_alias { T.nilable(T.proc.params(arg0: T.untyped).returns(T.untyped)) }
 
   sig {
+    params(feature_names: Symbol).returns(Micro::Struct::Factory)
+  }
+  def self.with(*feature_names)
+  end
+
+  sig {
+    params(feature_names: Symbol).returns(Micro::Struct::Factory)
+  }
+  def self.[](*feature_names)
+  end
+
+  sig {
     params(
       members:  STR_OR_SYMBOL,
       required: T.nilable(T.any(STR_OR_SYMBOL, T::Array[STR_OR_SYMBOL])),
@@ -14,12 +26,6 @@ module Micro::Struct
     .returns(T.class_of(Struct))
   }
   def self.new(*members, required: nil, optional: nil, &block)
-  end
-
-  sig {
-    params(feature_names: Symbol).returns(Micro::Struct::Factory)
-  }
-  def self.with(*feature_names)
   end
 
   sig {

--- a/test/micro/struct/factory_methods_test.rb
+++ b/test/micro/struct/factory_methods_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Micro::Factory_Methods_Test < Minitest::Test
+  def test_the_with_alias_method
+    assert_equal(
+      Micro::Struct.method(:with).original_name,
+      Micro::Struct.method(:[]).original_name
+    )
+  end
+end

--- a/test/micro/struct/features/exposed_features_test.rb
+++ b/test/micro/struct/features/exposed_features_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 class Micro::Struct_Features_ExposedFeatures_Test < Minitest::Test
   Person0 = Micro::Struct.new(:name)
-  Person1 = Micro::Struct.with(:readonly).new(:name)
+  Person1 = Micro::Struct[:readonly].new(:name)
 
   def test_the_struct_does_not_have_the_features_methods
     refute_respond_to Person0, :features
@@ -15,7 +15,7 @@ class Micro::Struct_Features_ExposedFeatures_Test < Minitest::Test
   end
 
   Person2 = Micro::Struct.with(:exposed_features).new(:name)
-  Person3 = Micro::Struct.with(:exposed_features, :readonly, :to_proc).new(:name)
+  Person3 = Micro::Struct[:exposed_features, :readonly, :to_proc].new(:name)
 
   def test_the_struct_has_the_features_methods
     assert_respond_to Person2, :features

--- a/test/micro/struct/features/to_proc_and_to_ary_to_hash_test.rb
+++ b/test/micro/struct/features/to_proc_and_to_ary_to_hash_test.rb
@@ -4,10 +4,10 @@ require 'test_helper'
 
 class Micro::Struct_Features_ToProc_ToAry_ToHash_Test < Minitest::Test
   With_ToAry = Micro::Struct.with(:to_ary)
-  With_ToAry_ToHash = Micro::Struct.with(:to_ary, :to_hash)
+  With_ToAry_ToHash = Micro::Struct[:to_ary, :to_hash]
   With_ToAry_ToProc = Micro::Struct.with(:to_ary, :to_proc)
 
-  With_ToHash = Micro::Struct.with(:to_hash)
+  With_ToHash = Micro::Struct[:to_hash]
   With_ToHash_ToProc = Micro::Struct.with(:to_hash, :to_proc)
 
   With_ToProc = Micro::Struct.with(:to_proc)


### PR DESCRIPTION
```ruby
Micro::Struct[:readonly] # is the same as Micro::Struct.with(:readonly)
```