### PR TITLE
Add Micro::Struct.immutable and .readonly methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,34 +6,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - [[Unreleased]](#unreleased)
-- [[0.12.0] - 2021-12-22](#0120---2021-12-22)
   - [Added](#added)
-- [[0.11.0] - 2021-12-19](#0110---2021-12-19)
+- [[1.0.0] - 2021-01-19](#100---2021-01-19)
+- [[0.12.0] - 2021-12-22](#0120---2021-12-22)
   - [Added](#added-1)
+- [[0.11.0] - 2021-12-19](#0110---2021-12-19)
+  - [Added](#added-2)
 - [[0.10.0] - 2021-12-15](#0100---2021-12-15)
   - [Changed](#changed)
 - [[0.9.0] - 2021-12-14](#090---2021-12-14)
-  - [Added](#added-2)
+  - [Added](#added-3)
   - [Changed](#changed-1)
 - [[0.8.0] - 2021-12-05](#080---2021-12-05)
-  - [Added](#added-3)
-- [[0.7.0] - 2021-12-04](#070---2021-12-04)
   - [Added](#added-4)
+- [[0.7.0] - 2021-12-04](#070---2021-12-04)
+  - [Added](#added-5)
   - [Changed](#changed-2)
 - [[0.6.0] - 2021-12-03](#060---2021-12-03)
-  - [Added](#added-5)
-- [[0.5.0] - 2021-12-02](#050---2021-12-02)
   - [Added](#added-6)
-- [[0.4.0] - 2021-12-02](#040---2021-12-02)
+- [[0.5.0] - 2021-12-02](#050---2021-12-02)
   - [Added](#added-7)
+- [[0.4.0] - 2021-12-02](#040---2021-12-02)
+  - [Added](#added-8)
 - [[0.3.1] - 2021-12-02](#031---2021-12-02)
   - [Fixed](#fixed)
 - [[0.3.0] - 2021-12-02](#030---2021-12-02)
-  - [Added](#added-8)
-- [[0.2.0] - 2021-12-02](#020---2021-12-02)
   - [Added](#added-9)
-- [[0.1.0] - 2021-12-02](#010---2021-12-02)
+- [[0.2.0] - 2021-12-02](#020---2021-12-02)
   - [Added](#added-10)
+- [[0.1.0] - 2021-12-02](#010---2021-12-02)
+  - [Added](#added-11)
 
 ## [Unreleased]
 
@@ -46,6 +48,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Micro::Struct[:readonly] # is the same as Micro::Struct.with(:readonly)
   ```
 
+- Add `Micro::Struct.immutable` method as a shortcut to `Micro::Struct.with(:readonly, :instance_copy)`.
+  It also accepts the `with:` option, which can be used to define additional features.
+  ```ruby
+  Micro::Struct.immutable.new(:name)
+
+  Micro::Struct.immutable.new(:name) do
+    def hi(other_name)
+      "Hi, #{other_name}! My name is #{name}"
+    end
+  end
+
+  Micro::Struct.immutable(with: :to_hash).new(:name)
+
+  Micro::Struct.immutable(with: [:to_hash, :to_proc]).new(:name)
+
+  Micro::Struct.immutable.instance(name: 'Rodrigo')
+
+  Micro::Struct.immutable(with: [:to_hash]).instance(name: 'Serradura')
+  ```
+
+- Add `Micro::Struct.readonly` method as a shortcut to `Micro::Struct.with(:readonly)`.
+  It has the same properties of `Micro::Struct.immutable`.
+  ```ruby
+  Micro::Struct.readonly.new(:name)
+
+  Micro::Struct.readonly.new(:name) do
+    def hi(other_name)
+      "Hi, #{other_name}! My name is #{name}"
+    end
+  end
+
+  Micro::Struct.readonly(with: :to_hash).new(:name)
+
+  Micro::Struct.readonly(with: [:to_hash, :to_proc]).new(:name)
+
+  Micro::Struct.readonly.instance(name: 'Rodrigo')
+
+  Micro::Struct.readonly(with: [:to_hash]).instance(name: 'Serradura')
+  ```
 **Development stuff**
 
 - Set up Rubocop.

--- a/Gemfile
+++ b/Gemfile
@@ -5,18 +5,18 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in micro-struct.gemspec
 gemspec
 
-gem 'rake', '~> 13.0'
+gem 'rake', '13.0.6'
 
-gem 'minitest', '~> 5.0'
+gem 'minitest', '5.15.0'
 
 if RUBY_VERSION >= '2.5.0'
-  gem 'rubocop',          '~> 1.25'
-  gem 'rubocop-minitest', '~> 0.17.0'
-  gem 'rubocop-rake',     '~> 0.6.0'
-  gem 'simplecov',        '~> 0.21.2'
+  gem 'rubocop',          '1.26'
+  gem 'rubocop-minitest', '0.18.0'
+  gem 'rubocop-rake',     '0.6.0'
+  gem 'simplecov',        '0.21.2'
 end
 
 if RUBY_VERSION >= '2.7.0'
-  gem 'sorbet',  '~> 0.5.9542'
-  gem 'tapioca', '~> 0.6.2'
+  gem 'sorbet', '0.5.9775'
+  gem 'tapioca', '0.7.0'
 end

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@
     - [`:instance_copy`](#instance_copy)
     - [`:exposed_features`](#exposed_features)
   - [`Micro::Struct.instance` or `Micro::Struct.with(...).instance`](#microstructinstance-or-microstructwithinstance)
+  - [`Micro::Struct.immutable`](#microstructimmutable)
+  - [`Micro::Struct.readonly`](#microstructreadonly)
   - [TL;DR](#tldr)
 - [FAQ](#faq)
   - [How to override the Struct `.new` method?](#how-to-override-the-struct-new-method)
@@ -519,6 +521,67 @@ end
 
 person3.name # => "Rodrigo Serradura"
 person4.name # => "Rodrigo Serradura"
+```
+
+<p align="right">(<a href="#table-of-contents-">⬆️ &nbsp;back to top</a>)</p>
+
+### `Micro::Struct.immutable`
+
+This method is as a shortcut to `Micro::Struct.with(:readonly, :instance_copy)`.
+As it is quite common to see the usage of these two features, I decided to create this method to improve the DX.
+
+Additional info:
+1. It accepts the `with:` option, which can be used to define additional features.
+2. The `.instance` method can be called after its usage.
+
+Usage examples:
+
+```ruby
+Micro::Struct.immutable.new(:name)
+
+Micro::Struct.immutable.new(:name) do
+  def hi(other_name)
+    "Hi, #{other_name}! My name is #{name}"
+  end
+end
+
+Micro::Struct.immutable(with: :to_hash).new(:name)
+
+Micro::Struct.immutable(with: [:to_hash, :to_proc]).new(:name)
+
+Micro::Struct.immutable.instance(name: 'Rodrigo')
+
+Micro::Struct.immutable(with: [:to_hash]).instance(name: 'Serradura')
+```
+
+<p align="right">(<a href="#table-of-contents-">⬆️ &nbsp;back to top</a>)</p>
+
+### `Micro::Struct.readonly`
+
+This method is as a shortcut to `Micro::Struct.with(:readonly)`.
+
+Additional info:
+1. It accepts the `with:` option, which can be used to define additional features.
+2. The `.instance` method can be called after its usage.
+
+Usage examples:
+
+```ruby
+Micro::Struct.readonly.new(:name)
+
+Micro::Struct.readonly.new(:name) do
+  def hi(other_name)
+    "Hi, #{other_name}! My name is #{name}"
+  end
+end
+
+Micro::Struct.readonly(with: :to_hash).new(:name)
+
+Micro::Struct.readonly(with: [:to_hash, :to_proc]).new(:name)
+
+Micro::Struct.readonly.instance(name: 'Rodrigo')
+
+Micro::Struct.readonly(with: [:to_hash]).instance(name: 'Serradura')
 ```
 
 <p align="right">(<a href="#table-of-contents-">⬆️ &nbsp;back to top</a>)</p>

--- a/lib/micro/struct.rb
+++ b/lib/micro/struct.rb
@@ -62,7 +62,7 @@ module Micro
     extend self
 
     def with(*feature_names)
-      Factory.new(feature_names)
+      factory(feature_names)
     end
 
     alias_method :[], :with
@@ -74,5 +74,27 @@ module Micro
     def instance(**members, &block)
       with.instance(**members, &block)
     end
+
+    READONLY = [:readonly].freeze
+    IMMUTABLE = [:readonly, :instance_copy].freeze
+    EMPTY_ARRAY = [].freeze
+
+    def readonly(with: EMPTY_ARRAY)
+      factory(with, READONLY)
+    end
+
+    def immutable(with: EMPTY_ARRAY)
+      factory(with, IMMUTABLE)
+    end
+
+    private
+
+    def factory(names, defaults = EMPTY_ARRAY)
+      features = ::Kernel.Array(names)
+
+      Factory.new(defaults.empty? ? features : defaults + features)
+    end
+
+    private_constant :READONLY, :IMMUTABLE, :EMPTY_ARRAY
   end
 end

--- a/rbi/micro/struct.rbi
+++ b/rbi/micro/struct.rbi
@@ -37,4 +37,32 @@ module Micro::Struct
   }
   def self.instance(**members, &block)
   end
+
+  READONLY = T.let(T::Array[Symbol])
+  IMMUTABLE = T.let(T::Array[Symbol])
+  EMPTY_ARRAY = T.let(T::Array)
+
+  sig {
+    params(with: T::Array[Symbol]).returns(Micro::Struct::Factory)
+  }
+  def readonly(with: EMPTY_ARRAY)
+  end
+
+  sig {
+    params(with: T::Array[Symbol]).returns(Micro::Struct::Factory)
+  }
+  def immutable(with: EMPTY_ARRAY)
+  end
+
+  private
+
+  sig {
+    params(
+      names: T.nilable(T::Array[Symbol]),
+      defaults: T::Array[Symbol]
+    )
+    .returns(Micro::Struct::Factory)
+  }
+  def factory(names, defaults = EMPTY_ARRAY)
+  end
 end

--- a/test/micro/struct/features/exposed_features_test.rb
+++ b/test/micro/struct/features/exposed_features_test.rb
@@ -29,17 +29,17 @@ class Micro::Struct_Features_ExposedFeatures_Test < Minitest::Test
     assert_same Person2.features, Person2.features
     assert_same Person3.features, Person3.features
 
-    assert Person2.features.frozen?
-    assert Person3.features.frozen?
+    assert_predicate Person2.features, :frozen?
+    assert_predicate Person3.features, :frozen?
 
-    assert Person2.features.frozen?
-    assert Person3.features.frozen?
+    assert_predicate Person2.features, :frozen?
+    assert_predicate Person3.features, :frozen?
 
     assert_empty Person2.features.names
     assert_equal [:readonly, :to_proc], Person3.features.names
 
-    assert Person2.features.options.frozen?
-    assert Person3.features.options.frozen?
+    assert_predicate Person2.features.options, :frozen?
+    assert_predicate Person3.features.options, :frozen?
 
     assert_equal(
       {to_ary: false, to_hash: false, to_proc: false, readonly: false, instance_copy: false},

--- a/test/micro/struct/methods/immutable_test.rb
+++ b/test/micro/struct/methods/immutable_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Micro::Struct_Methods_Immutable_Test < Minitest::Test
+  Person1 = Micro::Struct[:instance_copy].new(:first_name, :last_name)
+  Person2 = Micro::Struct.immutable.new(:first_name, :last_name)
+
+  def test_attributes_reading
+    person = Person1.new(first_name: 'Rodrigo', last_name: 'Serradura')
+
+    assert_instance_of(Person1, person)
+
+    assert_equal('Rodrigo', person.first_name)
+    assert_equal('Serradura', person.last_name)
+  end
+
+  def test_attributes_writing
+    person1 = Person1.new(first_name: 'Rodrigo', last_name: 'Serradura')
+
+    assert_equal('Rodrigo', person1.first_name)
+    assert_equal('Serradura', person1.last_name)
+
+    person1.first_name = 'Foo'
+    person1.last_name = 'Bar'
+
+    assert_equal('Foo', person1.first_name)
+    assert_equal('Bar', person1.last_name)
+
+    # ---
+
+    person2 = Person2.new(first_name: 'Rodrigo', last_name: 'Serradura')
+
+    error1 = assert_raises(NoMethodError) { person2.first_name = 'Bar' }
+
+    assert_match(/private method `first_name=' called for .*Person2/, error1.message)
+
+    error2 = assert_raises(NoMethodError) { person2.last_name = 'Foo' }
+
+    assert_match(/private method `last_name=' called for .*Person2/, error2.message)
+  end
+
+  def test_instance_copying
+    [Person1, Person2].each do |struct|
+      person_a = struct.new(first_name: 'Rodrigo', last_name: 'Serradura')
+
+      person_b = person_a.with(last_name: 'Foo')
+
+      assert_equal('Rodrigo', person_a.first_name)
+      assert_equal('Serradura', person_a.last_name)
+
+      assert_equal('Rodrigo', person_b.first_name)
+      assert_equal('Foo', person_b.last_name)
+
+      refute_same(person_a, person_b)
+    end
+  end
+
+  Person3 = Micro::Struct.immutable(with: :exposed_features).new(:first_name, :last_name)
+  Person4 = Micro::Struct.immutable(with: [:exposed_features, :to_ary]).new(:first_name, :last_name)
+
+  def test_the_adding_of_additional_features
+    assert_equal(
+      {to_ary: false, to_hash: false, to_proc: false, readonly: true, instance_copy: true},
+      Person3.features.options
+    )
+
+    assert_equal(
+      {to_ary: true, to_hash: false, to_proc: false, readonly: true, instance_copy: true},
+      Person4.features.options
+    )
+  end
+end

--- a/test/micro/struct/methods/readonly_test.rb
+++ b/test/micro/struct/methods/readonly_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Micro::Struct_Methods_readonly_Test < Minitest::Test
+  Person1 = Micro::Struct.new(:first_name, :last_name)
+  Person2 = Micro::Struct.readonly.new(:first_name, :last_name)
+
+  def test_attributes_reading
+    [Person1, Person2].each do |struct|
+      person = struct.new(first_name: 'Rodrigo', last_name: 'Serradura')
+
+      assert_instance_of(struct, person)
+
+      assert_equal('Rodrigo', person.first_name)
+      assert_equal('Serradura', person.last_name)
+    end
+  end
+
+  def test_attributes_writing
+    person1 = Person1.new(first_name: 'Rodrigo', last_name: 'Serradura')
+
+    assert_equal('Rodrigo', person1.first_name)
+    assert_equal('Serradura', person1.last_name)
+
+    person1.first_name = 'Foo'
+    person1.last_name = 'Bar'
+
+    assert_equal('Foo', person1.first_name)
+    assert_equal('Bar', person1.last_name)
+
+    # --
+
+    person2 = Person2.new(first_name: 'Rodrigo', last_name: 'Serradura')
+
+    error1 = assert_raises(NoMethodError) { person2.first_name = 'Bar' }
+
+    assert_match(/private method `first_name=' called for .*Person2/, error1.message)
+
+    error2 = assert_raises(NoMethodError) { person2.last_name = 'Foo' }
+
+    assert_match(/private method `last_name=' called for .*Person2/, error2.message)
+
+    error2 = assert_raises(NoMethodError) { person2[:last_name] = 'Foo' }
+
+    assert_match(/private method `\[\]=' called for .*Person2/, error2.message)
+  end
+
+  def test_instance_copying
+    [Person1, Person2].each do |struct|
+      person = struct.new(first_name: 'Rodrigo', last_name: 'Serradura')
+
+      error = assert_raises(NoMethodError) { person.with(last_name: 'Bar') }
+
+      assert_match(/undefined method `with' for .*Person[12]/, error.message)
+    end
+  end
+
+  Person3 = Micro::Struct.readonly(with: :exposed_features).new(:first_name, :last_name)
+  Person4 = Micro::Struct.readonly(with: [:exposed_features, :to_ary]).new(:first_name, :last_name)
+
+  def test_the_adding_of_additional_features
+    assert_equal(
+      {to_ary: false, to_hash: false, to_proc: false, readonly: true, instance_copy: false},
+      Person3.features.options
+    )
+
+    assert_equal(
+      {to_ary: true, to_hash: false, to_proc: false, readonly: true, instance_copy: false},
+      Person4.features.options
+    )
+  end
+end


### PR DESCRIPTION
- Add `Micro::Struct.immutable` method as a shortcut to `Micro::Struct.with(:readonly, :instance_copy)`.
  It also accepts the `with:` option, which can be used to define additional features.
  ```ruby
  Micro::Struct.immutable.new(:name)

  Micro::Struct.immutable.new(:name) do
    def hi(other_name)
      "Hi, #{other_name}! My name is #{name}"
    end
  end

  Micro::Struct.immutable(with: :to_hash).new(:name)

  Micro::Struct.immutable(with: [:to_hash, :to_proc]).new(:name)

  Micro::Struct.immutable.instance(name: 'Rodrigo')

  Micro::Struct.immutable(with: [:to_hash]).instance(name: 'Serradura')
  ```

- Add `Micro::Struct.readonly` method as a shortcut to `Micro::Struct.with(:readonly)`.
  It has the same properties of `Micro::Struct.immutable`.
  ```ruby
  Micro::Struct.readonly.new(:name)

  Micro::Struct.readonly.new(:name) do
    def hi(other_name)
      "Hi, #{other_name}! My name is #{name}"
    end
  end

  Micro::Struct.readonly(with: :to_hash).new(:name)

  Micro::Struct.readonly(with: [:to_hash, :to_proc]).new(:name)

  Micro::Struct.readonly.instance(name: 'Rodrigo')

  Micro::Struct.readonly(with: [:to_hash]).instance(name: 'Serradura')
  ```