### PR TITLE
Document u-struct's maintenance-mode / frozen-API policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,23 @@
 
 Notes for AI assistants working in `u-struct`.
 
+## Golden rule: maintenance mode — no new features, no breaking changes
+
+`u-struct` was created as an alternative to Ruby's native `Data`, which now
+ships with Ruby (3.2+). The gem is therefore considered unnecessary going
+forward and is kept **only to support existing applications**. There are **no
+plans to add new features** — new code should prefer native `Data`.
+
+The public API is **frozen**: every change must keep existing code working.
+Major version bumps are reserved for dependency-floor changes (dropping a Ruby
+or Rails version from the supported matrix) per SemVer — they do **not** signal
+a behavior break.
+
+So scope work to bug/compatibility fixes and supported-matrix upkeep. If a task
+as stated would add a feature or require a breaking change, stop and surface
+that — suggest native `Data` for new capabilities, or propose a backward-
+compatible path. Don't ship the break or the feature creep.
+
 ## How to work in this repo
 
 ### 1. Think before coding

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@
   <img src="https://img.shields.io/badge/Rails%20%3E%3D%206.0%2C%20%3C%3D%20Edge-rails.svg?colorA=444&colorB=333" alt="Rails">
 </p>
 
+> [!IMPORTANT]
+> **No breaking API changes — ever.** `u-struct`'s public API is frozen: every release stays backward-compatible, so code that builds on it keeps working.
+>
+> Major version bumps signal only that a Ruby or Rails version was dropped from the supported matrix — per SemVer, a dependency-floor change. Your code keeps working.
+
 # Table of contents: <!-- omit in toc -->
 - [Introduction](#introduction)
   - [Motivation](#motivation)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@
 > **No breaking API changes — ever.** `u-struct`'s public API is frozen: every release stays backward-compatible, so code that builds on it keeps working.
 >
 > Major version bumps signal only that a Ruby or Rails version was dropped from the supported matrix — per SemVer, a dependency-floor change. Your code keeps working.
+>
+> **Maintenance mode.** Ruby 3.2+ ships a native [`Data`](https://docs.ruby-lang.org/en/3.2/Data.html) type that covers this gem's use case; `u-struct` is kept only to support existing apps and gets no new features. New code should prefer `Data`.
 
 # Table of contents: <!-- omit in toc -->
 - [Introduction](#introduction)


### PR DESCRIPTION
Documents that `u-struct` is in maintenance mode with a frozen public API.

## Why
`u-struct` was created as an alternative to Ruby's native `Data` (introduced in Ruby 3.2). Now that `Data` ships with Ruby, the gem exists only to support existing applications — no new features planned. New code should prefer native `Data`.

## Changes
- **README** — adds an `[!IMPORTANT]` block at the top:
  - **No breaking API changes — ever** (API frozen; major bumps only drop a Ruby/Rails version from the supported matrix, never a behavior break). Adapted from u-attributes' disclaimer to u-struct's standalone reality — u-struct is **not** a u-case runtime dependency, so that rationale was dropped.
  - **Maintenance mode** — superseded by Ruby 3.2+ native `Data` (linked); kept only for existing apps; new code should prefer `Data`.
- **CLAUDE.md** — adds a `## Golden rule` section encoding the same policy for AI assistants: maintenance-only scope (bug/compat fixes + matrix upkeep), no new features, frozen API; surface-and-stop if a task would add a feature or break the API.

Docs only — no code or CI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)