### PR TITLE
docs: conform CHANGELOG to Keep a Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - [[Unreleased]](#unreleased)
 - [[1.1.0] - 2022-03-23](#110---2022-03-23)
   - [Added](#added)
-- [[1.0.0] - 2021-01-19](#100---2021-01-19)
+- [[1.0.0] - 2022-01-20](#100---2022-01-20)
 - [[0.12.0] - 2021-12-22](#0120---2021-12-22)
   - [Added](#added-1)
 - [[0.11.0] - 2021-12-19](#0110---2021-12-19)
@@ -39,8 +39,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [Added](#added-11)
 ## [Unreleased]
 
-[Diff](https://github.com/serradura/u-struct/compare/v1.1.0...main)
-
 ### Changed
 
 - Bump the minimum supported Ruby to `>= 2.7.0` (was `>= 2.2.0`).
@@ -49,7 +47,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0] - 2022-03-23
 
-[Diff](https://github.com/serradura/u-struct/compare/v1.0.0...v1.1.0) | [Tag](https://github.com/serradura/u-struct/tree/v1.1.0)
 ### Added
 
 - Add `Micro::Struct[]` as an alias of `Micro::Struct.with`.
@@ -103,17 +100,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <p align="right">(<a href="#changelog-">⬆️ &nbsp;back to top</a>)</p>
 
-## [1.0.0] - 2021-01-19
-
-[Diff](https://github.com/serradura/u-struct/compare/v0.12.0...v1.0.0) | [Tag](https://github.com/serradura/u-struct/tree/v1.0.0)
+## [1.0.0] - 2022-01-20
 
 - Review and update docs and examples. ;)
 
 <p align="right">(<a href="#changelog-">⬆️ &nbsp;back to top</a>)</p>
 
 ## [0.12.0] - 2021-12-22
-
-[Diff](https://github.com/serradura/u-struct/compare/v0.11.0...v0.12.0) | [Tag](https://github.com/serradura/u-struct/tree/v0.12.0)
 
 ### Added
 
@@ -187,8 +180,6 @@ Person.features.options?(:to_ary, :readonly)  # => false
 
 ## [0.11.0] - 2021-12-19
 
-[Diff](https://github.com/serradura/u-struct/compare/v0.10.0...v0.11.0) | [Tag](https://github.com/serradura/u-struct/tree/v0.11.0)
-
 ### Added
 
 - Reduce the required Ruby version to `>= 2.2.0`.
@@ -198,8 +189,6 @@ Person.features.options?(:to_ary, :readonly)  # => false
 <p align="right">(<a href="#changelog-">⬆️ &nbsp;back to top</a>)</p>
 
 ## [0.10.0] - 2021-12-15
-
-[Diff](https://github.com/serradura/u-struct/compare/v0.9.0...v0.10.0) | [Tag](https://github.com/serradura/u-struct/tree/v0.10.0)
 
 ### Changed
 
@@ -234,8 +223,6 @@ rgb_color.to_hex
 <p align="right">(<a href="#changelog-">⬆️ &nbsp;back to top</a>)</p>
 
 ## [0.9.0] - 2021-12-14
-
-[Diff](https://github.com/serradura/u-struct/compare/v0.8.0...v0.9.0) | [Tag](https://github.com/serradura/u-struct/tree/v0.9.0)
 
 ### Added
 
@@ -326,8 +313,6 @@ rgb_color.to_hash # => {:r=>1, :g=>5, :b=>255}
 
 ## [0.8.0] - 2021-12-05
 
-[Diff](https://github.com/serradura/u-struct/compare/v0.7.0...v0.8.0) | [Tag](https://github.com/serradura/u-struct/tree/v0.8.0)
-
 ### Added
 
 - Add `.===` to the module, it delegates the calling to its struct.
@@ -345,8 +330,6 @@ Person === person
 <p align="right">(<a href="#changelog-">⬆️ &nbsp;back to top</a>)</p>
 
 ## [0.7.0] - 2021-12-04
-
-[Diff](https://github.com/serradura/u-struct/compare/v0.6.0...v0.7.0) | [Tag](https://github.com/serradura/u-struct/tree/v0.7.0)
 
 ### Added
 
@@ -377,8 +360,6 @@ Person = Micro::Struct.new(
 
 ## [0.6.0] - 2021-12-03
 
-[Diff](https://github.com/serradura/u-struct/compare/v0.5.0...v0.6.0) | [Tag](https://github.com/serradura/u-struct/tree/v0.6.0)
-
 ### Added
 
 - Add the capability to create a struct with optional members.
@@ -403,8 +384,6 @@ Persona.new
 <p align="right">(<a href="#changelog-">⬆️ &nbsp;back to top</a>)</p>
 
 ## [0.5.0] - 2021-12-02
-
-[Diff](https://github.com/serradura/u-struct/compare/v0.4.0...v0.5.0) | [Tag](https://github.com/serradura/u-struct/tree/v0.5.0)
 
 ### Added
 
@@ -457,8 +436,6 @@ new_person.name # => "John Doe"
 
 ## [0.4.0] - 2021-12-02
 
-[Diff](https://github.com/serradura/u-struct/compare/v0.3.1...v0.4.0) | [Tag](https://github.com/serradura/u-struct/tree/v0.4.0)
-
 ### Added
 
 - Add `.members` to the module, it delegates the calling to its struct.
@@ -488,8 +465,6 @@ Person.respond_to?(:to_proc) # => false
 
 ## [0.3.1] - 2021-12-02
 
-[Diff](https://github.com/serradura/u-struct/compare/v0.3.0...v0.3.1) | [Tag](https://github.com/serradura/u-struct/tree/v0.3.1)
-
 ### Fixed
 
 - Fix the spec.files config of `u-struct.gemspec`.
@@ -498,8 +473,6 @@ Person.respond_to?(:to_proc) # => false
 
 ## [0.3.0] - 2021-12-02
 
-[Diff](https://github.com/serradura/u-struct/compare/v0.2.0...v0.3.0) | [Tag](https://github.com/serradura/u-struct/tree/v0.3.0)
-
 ### Added
 
 - Add `lib/u-struct.rb` to allow the bundler to require the gem in an automatic way.
@@ -507,8 +480,6 @@ Person.respond_to?(:to_proc) # => false
 <p align="right">(<a href="#changelog-">⬆️ &nbsp;back to top</a>)</p>
 
 ## [0.2.0] - 2021-12-02
-
-[Diff](https://github.com/serradura/u-struct/compare/v0.1.0...v0.2.0) | [Tag](https://github.com/serradura/u-struct/tree/v0.2.0)
 
 ### Added
 
@@ -529,8 +500,6 @@ print_first_and_last_name(**person) # Rodrigo Serradura
 <p align="right">(<a href="#changelog-">⬆️ &nbsp;back to top</a>)</p>
 
 ## [0.1.0] - 2021-12-02
-
-[Diff](https://github.com/serradura/u-struct/compare/19beceb97a9bc22f2a485b82e4002b6a2e20a73c...v0.1.0) | [Tag](https://github.com/serradura/u-struct/tree/v0.1.0)
 
 ### Added
 
@@ -592,3 +561,20 @@ Person::Struct.new
 ```
 
 <p align="right">(<a href="#changelog-">⬆️ &nbsp;back to top</a>)</p>
+
+[Unreleased]: https://github.com/serradura/u-struct/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/serradura/u-struct/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/serradura/u-struct/compare/v0.12.0...v1.0.0
+[0.12.0]: https://github.com/serradura/u-struct/compare/v0.11.0...v0.12.0
+[0.11.0]: https://github.com/serradura/u-struct/compare/v0.10.0...v0.11.0
+[0.10.0]: https://github.com/serradura/u-struct/compare/v0.9.0...v0.10.0
+[0.9.0]: https://github.com/serradura/u-struct/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/serradura/u-struct/compare/v0.7.0...v0.8.0
+[0.7.0]: https://github.com/serradura/u-struct/compare/v0.6.0...v0.7.0
+[0.6.0]: https://github.com/serradura/u-struct/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/serradura/u-struct/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/serradura/u-struct/compare/v0.3.1...v0.4.0
+[0.3.1]: https://github.com/serradura/u-struct/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/serradura/u-struct/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/serradura/u-struct/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/serradura/u-struct/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 <p align="center">
   <h1 align="center">🧱 μ-struct</h1>
   <p align="center"><i>Create powered Ruby structs.</i></p>
-  <br>
 </p>
 
 <p align="center">
@@ -27,6 +26,7 @@
 > **Maintenance mode.** Ruby 3.2+ ships a native [`Data`](https://docs.ruby-lang.org/en/3.2/Data.html) type that covers this gem's use case; `u-struct` is kept only to support existing apps and gets no new features. New code should prefer `Data`.
 
 # Table of contents: <!-- omit in toc -->
+
 - [Introduction](#introduction)
   - [Motivation](#motivation)
 - [Installation](#installation)
@@ -295,6 +295,7 @@ person.name       # "Rodrigo Serradura"
 This method can do two things: first, it can create `Struct` factories; second, it sets some special behavior to their structs.
 
 These are all of the available features which you can use (pick one, many, or all of them):
+
 - [`:to_ary`](#to_ary)
 - [`:to_hash`](#to_hash)
 - [`:to_proc`](#to_proc)
@@ -340,6 +341,7 @@ new_person.class == person.class
 ### `Micro::Struct[]`
 
 The `[]` brackets method is as an alias of `Micro::Struct.with`. e.g.
+
 ```ruby
 Micro::Struct[:readonly, :to_hash] # is the same as Micro::Struct.with(:readonly, :to_hash)
 ```
@@ -537,6 +539,7 @@ This method is as a shortcut to `Micro::Struct.with(:readonly, :instance_copy)`.
 As it is quite common to see the usage of these two features, I decided to create this method to improve the DX.
 
 Additional info:
+
 1. It accepts the `with:` option, which can be used to define additional features.
 2. The `.instance` method can be called after its usage.
 
@@ -567,6 +570,7 @@ Micro::Struct.immutable(with: [:to_hash]).instance(name: 'Serradura')
 This method is as a shortcut to `Micro::Struct.with(:readonly)`.
 
 Additional info:
+
 1. It accepts the `with:` option, which can be used to define additional features.
 2. The `.instance` method can be called after its usage.
 
@@ -749,6 +753,7 @@ RGBColor.new(red: 1, green: -1, blue: 255)
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 Additional tools:
+
 - Sorbet (type checker): `bundle exec srb tc` (requires `Ruby >= 2.7`).
 - Rubocop (linter and code formatter): `bundle rubocop` (requires `Ruby >= 2.5`).
 


### PR DESCRIPTION
## What

Docs-only cleanup of `CHANGELOG.md` and `README.md`.

### CHANGELOG.md
- Conform to [Keep a Changelog](https://keepachangelog.com/): replace the inline per-release `[Diff]` / `[Tag]` links with reference-style version links collected at the bottom of the file, and bump the format reference to `1.1.0`.
- Fix the `1.0.0` release date: `2021-01-19` → `2022-01-20`. The old date was chronologically impossible (it predated `0.12.0` at `2021-12-22`); `2022-01-20` matches the actual `v1.0.0` git tag.

### README.md
- Add blank lines before lists and code blocks (markdown best practice / consistent rendering); drop a stray `<br>`.

## Why

Keep the user-facing changelog consistent with the conventions it already claims to follow, and correct the inaccurate `1.0.0` date.

## Notes
- No code changes; public API untouched (maintenance mode honored).
- No CHANGELOG `[Unreleased]` entry — pure docs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)